### PR TITLE
Added CA Cert to options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Usage
 
 Load the code::
     >>> from foreman import Foreman
-    >>> foreman = Foreman(login=args["admin"], password=args["password"], ip=args["ip"])
+    >>> foreman = Foreman(login=args["admin"], password=args["password"], ip=args["ip"], ca_cert='example.crt')
 
 Manipulate hosts::
     >>> foreman.hosts.keys()

--- a/foreman/__init__.py
+++ b/foreman/__init__.py
@@ -36,16 +36,18 @@ class Foreman:
     """
     HostGroup class
     """
-    def __init__(self, password, login='admin', ip='127.0.0.1'):
+    def __init__(self, password, login='admin', ip='127.0.0.1', ca_cert=None):
         """ Function __init__
         Init the API with the connection params
         @param password: authentication password
         @param password: authentication login - default is admin
         @param ip: api ip - default is localhost
+        @param ca_cert: CA Certificate for SSL connection
+        @param ca_cert:  Defaults to system CA certs, set for self-signed
         @return RETURN: self
         """
         self.api = Api(login=login, password=password, ip=ip,
-                       printErrors=False)
+                       printErrors=False, ca_cert=ca_cert)
         self.domains = Domains(self.api)
         self.smartProxies = SmartProxies(self.api)
         self.puppetClasses = PuppetClasses(self.api)

--- a/foreman/api.py
+++ b/foreman/api.py
@@ -30,7 +30,7 @@ class Api:
     maxHistory = 16
 
     def __init__(self, password, login='admin', ip='127.0.0.1',
-                 printErrors=False):
+                 printErrors=False, ca_cert=None):
         """ Function __init__
         Init the API with the connection params
 
@@ -43,6 +43,7 @@ class Api:
         self.headers = {'Accept': 'version=2',
                         'Content-Type': 'application/json; charset=UTF-8'}
         self.auth = (login, password)
+        self.ca_cert = ca_cert
         self.history = []
         self.clearReqVars()
 
@@ -96,7 +97,7 @@ class Api:
         if filter:
             self.url += '&search={}'.format(filter)
         self.resp = requests.get(url=self.url, auth=self.auth,
-                                 headers=self.headers)
+                                 headers=self.headers, cert=self.ca_cert)
         if only_id:
             if self.__process_resp__(obj) is False:
                 return False
@@ -127,7 +128,7 @@ class Api:
         if sub_object:
             self.url += '/' + sub_object
         self.resp = requests.get(url=self.url, auth=self.auth,
-                                 headers=self.headers)
+                                 headers=self.headers, cert=self.ca_cert)
         if self.__process_resp__(obj):
             return self.res
         return False
@@ -166,10 +167,10 @@ class Api:
         if async:
             session = FuturesSession()
             return session.put(url=self.url, auth=self.auth,
-                               headers=self.headers, data=self.payload)
+                               headers=self.headers, data=self.payload, cert=self.ca_cert)
         else:
             self.resp = requests.put(url=self.url, auth=self.auth,
-                                     headers=self.headers, data=self.payload)
+                                     headers=self.headers, data=self.payload, cert=self.ca_cert)
             if self.__process_resp__(obj):
                 return self.res
             return False
@@ -192,12 +193,12 @@ class Api:
             self.method = 'POST(Async)'
             session = FuturesSession()
             self.resp = session.post(url=self.url, auth=self.auth,
-                                headers=self.headers, data=self.payload)
+                                headers=self.headers, data=self.payload, cert=self.ca_cert)
             return self.resp
         else:
             self.resp = requests.post(url=self.url, auth=self.auth,
                                       headers=self.headers,
-                                      data=self.payload)
+                                      data=self.payload, cert=self.ca_cert)
             return self.__process_resp__(obj)
 
     @log
@@ -213,7 +214,7 @@ class Api:
         self.method = 'DELETE'
         self.resp = requests.delete(url=self.url,
                                     auth=self.auth,
-                                    headers=self.headers, )
+                                    headers=self.headers, cert=self.ca_cert, )
         return self.__process_resp__(obj)
 
     def __process_resp__(self, obj):


### PR DESCRIPTION
My foreman server uses a self-signed Cert and my version of requests defaults to Validate=True.

So I've added a quick option to allow users to pass their own CA certs in.