### PR TITLE
#6 renames async to isasync for py3.7

### DIFF
--- a/foreman/api.py
+++ b/foreman/api.py
@@ -147,7 +147,7 @@ class Api:
         return list[name] if name in list.keys() else False
 
     @log
-    def set(self, obj, id, payload, action='', async=False):
+    def set(self, obj, id, payload, action='', isasync=False):
         """ Function set
         Set an object by id
 
@@ -155,7 +155,7 @@ class Api:
         @param id: the id of the object (name or id)
         @param action: specific action of an object ('power'...)
         @param payload: the dict of the payload
-        @param async: should this request be async, if true use
+        @param isasync: should this request be async, if true use
                         return.result() to get the response
         @return RETURN: the server response
         """
@@ -164,7 +164,7 @@ class Api:
         if action:
             self.url += '/{}'.format(action)
         self.payload = json.dumps(payload)
-        if async:
+        if isasync:
             session = FuturesSession()
             return session.put(url=self.url, auth=self.auth,
                                headers=self.headers, data=self.payload,
@@ -178,20 +178,20 @@ class Api:
             return False
 
     @log
-    def create(self, obj, payload, async=False):
+    def create(self, obj, payload, isasync=False):
         """ Function create
         Create an new object
 
         @param obj: object name ('hosts', 'puppetclasses'...)
         @param payload: the dict of the payload
-        @param async: should this request be async, if true use
+        @param isasync: should this request be async, if true use
                         return.result() to get the response
         @return RETURN: the server response
         """
         self.url = self.base_url + obj
         self.method = 'POST'
         self.payload = json.dumps(payload)
-        if async:
+        if isasync:
             self.method = 'POST(Async)'
             session = FuturesSession()
             self.resp = session.post(url=self.url, auth=self.auth,

--- a/foreman/hosts.py
+++ b/foreman/hosts.py
@@ -61,12 +61,12 @@ class Hosts(ForemanObjects):
         """
         if key not in self:
             self.printer = printer
-            self.async = False
+            self.isasync = False
             # Create the VM in foreman
             self.__printProgression__('In progress',
                                       key + ' creation: push in Foreman',
                                       eol='\r')
-            self.api.create('hosts', attributes, async=self.async)
+            self.api.create('hosts', attributes, isasync=self.isasync)
             self[key]['interfaces'].append(ipmi)
             # Wait for puppet catalog to be applied
             # self.waitPuppetCatalogToBeApplied(key)
@@ -123,12 +123,12 @@ class Hosts(ForemanObjects):
         """
 
         self.printer = printer
-        self.async = False
+        self.isasync = False
         # Create the VM in foreman
         # NOTA: with 1.8 it will return 422 'Failed to login via SSH'
         self.__printProgression__('In progress',
                                   key + ' creation: push in Foreman', eol='\r')
-        asyncCreation = self.api.create('hosts', attributes, async=self.async)
+        asyncCreation = self.api.create('hosts', attributes, isasync=self.isasync)
 
         #  Wait before asking to power on the VM
         # sleep = 5

--- a/foreman/itemHost.py
+++ b/foreman/itemHost.py
@@ -99,7 +99,7 @@ class ItemHost(ForemanItem):
         """
         return self.api.set('hosts', self.key,
                             {"host": {}},
-                            'puppetrun', async=False)
+                            'puppetrun', isasync=False)
 
     def powerOn(self):
         """ Function powerOn
@@ -109,7 +109,7 @@ class ItemHost(ForemanItem):
         """
         return self.api.set('hosts', self.key,
                             {"power_action": "start"},
-                            'power', async=False)
+                            'power', isasync=False)
 
     def getParamFromEnv(self, var, default=''):
         """ Function getParamFromEnv

--- a/foreman/objects.py
+++ b/foreman/objects.py
@@ -50,7 +50,7 @@ class ForemanObjects(dict):
         if payloadObj:
             self.payloadObj = payloadObj
         # For asynchronous creations
-        self.async = False
+        self.isasync = False
         # Default params
         if index:
             self.index = index
@@ -119,7 +119,7 @@ class ForemanObjects(dict):
         if key not in self:
             payload = {self.payloadObj: {self.index: key}}
             payload[self.payloadObj].update(attributes)
-            return self.api.create(self.objName, payload, async=self.async)
+            return self.api.create(self.objName, payload, isasync=self.isasync)
         return False
 
     @updateAfterDecorator


### PR DESCRIPTION
Per issue #6, async is now a reserved word and needs to be renamed in order to support python version 3.7 and later.

**BREAKING CHANGE!**

This will cause code that previously used async= to fail, but is necessary for future support.